### PR TITLE
Validate env vars and document configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+INFURA_ID=your_infura_project_id
+REACT_APP_PAYMENT_CONTRACT_ADDRESS=0xYourContractAddress

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export function Checkout() {
         isOpen={isOpen}
         onClose={() => setOpen(false)}
         args={args}
+        usdValue="~ 6.80 USD"
         onSuccess={(hash) => setTxHash(hash)}
       />
       {txHash && <p>Tx hash: {txHash}</p>}
@@ -43,5 +44,20 @@ export function Checkout() {
   );
 }
 ```
+
+## Configuration
+
+The SDK expects the following environment variables to be defined:
+
+| Variable | Description |
+|----------|-------------|
+| `INFURA_ID` | Infura project ID used for WalletConnect fallback |
+| `REACT_APP_PAYMENT_CONTRACT_ADDRESS` | Address of the payment contract |
+
+Add them to a `.env` file or set them in your environment before running your application.
+
+### Permit vs Approve flow
+
+If the permit signature parameters (`deadline`, `v`, `r`, `s`) are provided in `PayArgs`, the SDK uses the gasless permit flow (EIP-2612). Otherwise, it falls back to the traditional `pay` function which requires prior token approval.
 
 ---

--- a/src/components/SandModal.tsx
+++ b/src/components/SandModal.tsx
@@ -8,11 +8,16 @@ interface SandModalProps {
   isOpen: boolean;
   onClose: () => void;
   args: PayArgs;
+  usdValue: string;
   onSuccess?: (txHash: string) => void;
 }
 
-export function SandModal({ isOpen, onClose, args, onSuccess }: SandModalProps) {
+export function SandModal({ isOpen, onClose, args, usdValue, onSuccess }: SandModalProps) {
   const [loading, setLoading] = React.useState(false);
+
+  if (!args.orderId || !args.recipient || !args.amount || !usdValue) {
+    return <div className="p-4 text-red-500">Missing required payment information</div>;
+  }
 
   const handleConfirm = async () => {
     setLoading(true);
@@ -27,11 +32,9 @@ export function SandModal({ isOpen, onClose, args, onSuccess }: SandModalProps) 
     }
   };
 
-  // Dummy data for illustration, replace with props if needed
-  const orderId = args.orderId || 'ABC-1234';
-  const destination = args.recipient || '0xAbc...7890';
+  const orderId = args.orderId;
+  const destination = args.recipient;
   const amount = ethers.utils.formatUnits(args.amount, 18);
-  const usdValue = '~ 6.80 USD'; // Replace with prop/calculation if needed
 
   return (
     <Dialog open={isOpen} onClose={onClose} className="fixed inset-0 z-50 flex items-center justify-center">

--- a/src/payWithSand.ts
+++ b/src/payWithSand.ts
@@ -21,13 +21,20 @@ export async function payWithSand(args: PayArgs): Promise<string> {
     provider = new ethers.providers.Web3Provider((window as any).ethereum);
     await provider.send('eth_requestAccounts', []);
   } else {
-    const wc = new WalletConnectProvider({ infuraId: process.env.INFURA_ID });
+    const infuraId = process.env.INFURA_ID;
+    if (!infuraId) {
+      throw new Error('INFURA_ID environment variable is required');
+    }
+    const wc = new WalletConnectProvider({ infuraId });
     await wc.enable();
     provider = new ethers.providers.Web3Provider(wc as any);
   }
 
+  const contractAddress = process.env.REACT_APP_PAYMENT_CONTRACT_ADDRESS;
+  if (!contractAddress) {
+    throw new Error('REACT_APP_PAYMENT_CONTRACT_ADDRESS environment variable is required');
+  }
   const signer = provider.getSigner();
-  const contractAddress = process.env.REACT_APP_PAYMENT_CONTRACT_ADDRESS!;
   const contract = new Contract(contractAddress, ABI, signer);
 
   // Use permit flow if signature params are present

--- a/src/useSandPaymentStatus.ts
+++ b/src/useSandPaymentStatus.ts
@@ -11,28 +11,44 @@ export function useSandPaymentStatus(orderId: string) {
   const [status, setStatus] = useState<'pending' | 'confirmed'>('pending');
 
   useEffect(() => {
+    let contract: ethers.Contract | null = null;
+    let filter: ethers.EventFilter | null = null;
+    let wc: WalletConnectProvider | null = null;
+
+    const handler = (_oid: string, _payer: string, _amount: ethers.BigNumber) => {
+      setStatus('confirmed');
+    };
+
     const setup = async () => {
       let provider;
       if ((window as any).ethereum) {
         provider = new ethers.providers.Web3Provider((window as any).ethereum);
       } else {
-        const wc = new WalletConnectProvider({ infuraId: process.env.INFURA_ID });
+        const infuraId = process.env.INFURA_ID;
+        if (!infuraId) {
+          throw new Error('INFURA_ID environment variable is required');
+        }
+        wc = new WalletConnectProvider({ infuraId });
         await wc.enable();
         provider = new ethers.providers.Web3Provider(wc as any);
       }
 
-      const contractAddress = process.env.REACT_APP_PAYMENT_CONTRACT_ADDRESS!;
-      const contract = new ethers.Contract(contractAddress, EVENT_ABI, provider);
-      const filter = contract.filters.PaymentDone(orderId);
-
-      contract.on(filter, (_oid, _payer, _amount) => {
-        setStatus('confirmed');
-      });
+      const contractAddress = process.env.REACT_APP_PAYMENT_CONTRACT_ADDRESS;
+      if (!contractAddress) {
+        throw new Error('REACT_APP_PAYMENT_CONTRACT_ADDRESS environment variable is required');
+      }
+      contract = new ethers.Contract(contractAddress, EVENT_ABI, provider);
+      filter = contract.filters.PaymentDone(orderId);
+      contract.on(filter, handler);
     };
+
     setup();
 
     return () => {
-      // provider and listeners will clean up on component unmount
+      if (contract && filter) {
+        contract.off(filter, handler);
+      }
+      wc?.disconnect?.();
     };
   }, [orderId]);
 


### PR DESCRIPTION
## Summary
- verify required env vars before initializing providers and contracts
- clean up payment status event listeners
- remove hardcoded placeholders from SandModal and document env setup

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896ab4935ac83309250afc94a44f47a