### PR TITLE
feat: add classic payment option and fix modal styles

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pay With Sand - Example</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -146,6 +146,11 @@ export function App() {
     }
   }
 
+  function openClassic() {
+    setArgs({ orderId: makeOrderId(), amount: AMOUNT_WEI, recipient: MERCHANT });
+    setOpen(true);
+  }
+
   const { usdValue } = useSandUsdValue(AMOUNT_WEI, 18);
 
   return (
@@ -153,9 +158,14 @@ export function App() {
       <h1>Pay With Sand - Example</h1>
       <p>Amount: 1 SAND</p>
       <p>Approx in USD: {usdValue || 'Loading...'}</p>
-      <button onClick={preparePermitAndOpen} style={{ padding: '8px 12px' }}>
-        Pay with SAND
-      </button>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={preparePermitAndOpen} style={{ padding: '8px 12px' }}>
+          Pay with SAND (Permit)
+        </button>
+        <button onClick={openClassic} style={{ padding: '8px 12px' }}>
+          Pay with SAND (Classic)
+        </button>
+      </div>
 
       <SandModal
         isOpen={open}


### PR DESCRIPTION
## Summary
- add tailwind css to fix modal styles
- support classic pay-with-sand flow alongside permit

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a82f1e20483308b31a8b4521b2c1b