### PR TITLE
Add Rainbow wallet option to payment modal

### DIFF
--- a/src/assets/Rainbow-icon.svg
+++ b/src/assets/Rainbow-icon.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="rainbowGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff5f6d" />
+      <stop offset="25%" stop-color="#ffc371" />
+      <stop offset="50%" stop-color="#47cf73" />
+      <stop offset="75%" stop-color="#36a3f7" />
+      <stop offset="100%" stop-color="#845ef7" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="16" fill="url(#rainbowGradient)" />
+  <path d="M18 38c0-7.732 6.268-14 14-14s14 6.268 14 14" stroke="#fff" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M22 38c0-5.523 4.477-10 10-10s10 4.477 10 10" stroke="#fff" stroke-width="3" stroke-linecap="round" opacity="0.7" fill="none"/>
+  <path d="M26 38c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.5" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Rainbow browser wallet as a selectable option in the payment modal
- detect injected Rainbow providers and connect them to the SDK signer flow
- include a Rainbow wallet icon asset for the modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3d48f475c833084a6822efb6f05ae